### PR TITLE
Add Jukebox Extended Reborn

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Most of these Extensions can be downloaded on the respective GitHub pages, usual
 If you wish to add your Extension to this list, create a PR!
 
 ### Currently working
+- **Jukebox Extended Reborn**: https://github.com/spartacus04/jext-reborn <br>
+  Level up your server with custom music discs. Allows JEXT to work with Geyser standalone.
 - **EmoteMenu**: https://github.com/Carbuino/EmoteMenu <br>
   Creates a quick menu for easy access for Geyser features and command execution, even with Xbox Achievements turned on. 
 - **GeyserConnect**: https://github.com/GeyserMC/GeyserConnect <br>


### PR DESCRIPTION
Currently supports both Geyser as a Spigot plugin, and Geyser Standalone.
The Extension is embedded inside the Plugin, meaning they have the same jar file.